### PR TITLE
added global event for indicating ongoing rendering

### DIFF
--- a/minimal/js/nexus.js
+++ b/minimal/js/nexus.js
@@ -1223,6 +1223,13 @@ function readyNode(node) {
 	m.status[n]--;
 
 	if(m.status[n] == 2) {
+
+		///////////
+		// Added event indicating rendering start
+		//
+        var event = new Event('threeDNodeRendered');
+        document.dispatchEvent(event);
+
 		m.status[n]--; //ready
 		node.reqAttempt = 0;
 		node.context.pending--;


### PR DESCRIPTION
Dear fantastic 3-D Hop developers,

this event could be used to stop a loading indicator when the viewer starts to render a 3d-model
(as far as I understand).
The browser event for "page finished loading" will fire before a larger model e.g. ~300mb and therefor stop the loading animation before the 3D model is displayed. 

e.g.
```
$(document).ready(function(){
         init3dhop();
         setup3dhop();
                       
                     
          let firstNodeCounter = 0;
          document.addEventListener('threeDNodeRendered', function () {
             if(firstNodeCounter===0){
                  //stop loading animation here

                  firstNodeCounter++;
              }
            });
           });
```